### PR TITLE
Fix aiogram handler injection issue

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -57,6 +57,7 @@ def record_test_result(user_id: int, points: int) -> None:
 def track_brand(name: str):
     def decorator(func):
         async def wrapper(m: Message, *a, **kw):
+            kw.pop("bot", None)  # aiogram may inject bot kwarg
             record_brand_view(m.from_user.id, name)
             return await func(m, *a, **kw)
         return wrapper


### PR DESCRIPTION
## Summary
- ignore injected `bot` kwarg in brand tracking decorator

## Testing
- `python3 -m py_compile bot.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6842c6e1b0fc8323b0d95a32860d0ea9