### PR TITLE
Fix brand selection fallback

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1078,5 +1078,14 @@ dp.include_routers(
 )
 
 
+@dp.message(lambda m: normalize(m.text) in ALIAS_MAP)
+async def fallback_brand(m: Message):
+    """Final handler to show brand info if text matches a known brand."""
+    clear_user_state(m.from_user.id)
+    canonical = ALIAS_MAP[normalize(m.text)]
+    handler, _ = BRANDS[canonical]
+    await handler(m)
+
+
 
 


### PR DESCRIPTION
## Summary
- ensure brand info is shown when brand name is sent
- add final fallback handler that uses `ALIAS_MAP` to lookup brand handlers

## Testing
- `python -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684544763c188323bd750ecb9870c931