### PR TITLE
Handle brand selection in search mode

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -889,11 +889,10 @@ async def process_search(m: Message):
         return
 
     if text in CANONICAL_MAP:
+        SEARCH_ACTIVE.discard(m.from_user.id)
         name = CANONICAL_MAP[text]
         handler, _ = BRANDS[name]
         await handler(m)
-        SEARCH_ACTIVE.discard(m.from_user.id)
-        await m.answer("Главное меню", reply_markup=MAIN_KB)
         return
 
     matches = [name for name, (_, aliases) in BRANDS.items() if any(text in a for a in aliases)]


### PR DESCRIPTION
## Summary
- exit search state before showing brand info
- display brand info immediately when matching a canonical name

## Testing
- `python -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684549ed93588323bad72d9977a52fa3