### PR TITLE
Fix search brand handler

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -870,7 +870,8 @@ async def show_brand(m: Message):
     await handler(m)
 
 
-CANONICAL_MAP = {normalize(name): name for name in BRANDS}
+# Map canonical brand names in lowercase for exact-match check
+CANONICAL_MAP = {name.lower(): name for name in BRANDS}
 
 @search_router.message(F.text == "🔍 Поиск")
 async def search_start(m: Message):
@@ -881,19 +882,21 @@ async def search_start(m: Message):
 
 @search_router.message(lambda m: m.from_user.id in SEARCH_ACTIVE)
 async def process_search(m: Message):
-    text = m.text.lower().strip()
-    normalized = normalize(m.text)
+    text = m.text.strip()
+    lower_text = text.lower()
+    normalized = normalize(text)
 
-    if text in {"отмена", "назад"}:
+    if lower_text in {"отмена", "назад"}:
         SEARCH_ACTIVE.discard(m.from_user.id)
         await m.answer("Поиск отменён", reply_markup=MAIN_KB)
         return
 
-    if normalized in CANONICAL_MAP:
+    if lower_text in CANONICAL_MAP:
         SEARCH_ACTIVE.discard(m.from_user.id)
-        name = CANONICAL_MAP[normalized]
+        name = CANONICAL_MAP[lower_text]
         handler, _ = BRANDS[name]
         await handler(m)
+        await m.answer("Главное меню", reply_markup=MAIN_KB)
         return
 
     matches = [


### PR DESCRIPTION
## Summary
- fix canonical brand search by lowercasing names
- exit search state, show brand info and main menu

## Testing
- `python -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68454e49e1e0832394be4a83eb6f3143