### PR TITLE
Fix search results list

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -891,14 +891,6 @@ async def process_search(m: Message):
         await m.answer("Поиск отменён", reply_markup=MAIN_KB)
         return
 
-    # Если введён бренд точно (название или алиас)
-    if normalized in ALIAS_MAP:
-        SEARCH_ACTIVE.discard(m.from_user.id)
-        canonical = ALIAS_MAP[normalized]
-        handler, _ = BRANDS[canonical]
-        await handler(m)
-        await m.answer("Главное меню", reply_markup=MAIN_KB)
-        return
 
     # Ищем все бренды, где есть совпадение
     matches: list[str] = []


### PR DESCRIPTION
## Summary
- fix search handler so partial matches show list of brands instead of immediately sending first hit

## Testing
- `python -m py_compile bot.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68455ce89570832398032d30da3b03ee