### PR TITLE
Add main menu button to truth game

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1132,7 +1132,7 @@ async def start_truth_game(m: Message):
     GAME_STATE[m.from_user.id] = {"step": 0, "score": 0}
     await m.answer(
         "Отвечайте Верю или Не верю на 20 утверждений о брендах.",
-        reply_markup=kb("Верю", "Не верю", width=2),
+        reply_markup=kb("Верю", "Не верю", "Главное меню", width=2),
     )
     await send_truth(m)
 
@@ -1166,7 +1166,7 @@ async def send_truth(m: Message):
     st["answer"] = truth
     await m.answer(
         f"{step + 1}/20. {statement}",
-        reply_markup=kb("Верю", "Не верю", width=2),
+        reply_markup=kb("Верю", "Не верю", "Главное меню", width=2),
     )
 
 @game_router.message(lambda m: m.from_user.id in GAME_STATE)


### PR DESCRIPTION
## Summary
- add "Главное меню" button to the true/false game so players can exit at any question

## Testing
- `python -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684582ac654c83239d6754e33363b8d3