### PR TITLE
Rename Game Zone menu

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -109,7 +109,7 @@ MAIN_KB = kb(
     "🔍 Поиск",
     "📋 Тесты",
     "🍹 Коктейли",
-    "🎮 Game Zone",
+    "🧠 Тренажёр знаний",
     "Моя статистика",
     width=2
 )
@@ -1162,8 +1162,8 @@ async def test_answer(m: Message):
     st["step"] += 1
     await ask(m)
 
-# --- Game Zone handlers ---
-@main_router.message(F.text == "🎮 Game Zone")
+# --- Тренажёр знаний handlers ---
+@main_router.message(F.text == "🧠 Тренажёр знаний")
 async def game_menu(m: Message):
     clear_user_state(m.from_user.id)
     await m.answer("Выберите игру:", reply_markup=GAME_MENU_KB)


### PR DESCRIPTION
## Summary
- rename the Game Zone menu item to "🧠 Тренажёр знаний"
- adjust the handler trigger to the new section name

## Testing
- `python -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684590a641988323a949be6d2ad836b0