### PR TITLE
Randomize blitz options

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1432,10 +1432,12 @@ async def send_blitz(m: Message):
         BLITZ_STATE.pop(m.from_user.id, None)
         return
     question, options, correct = BLITZ_QUESTIONS[step]
+    shuffled = options[:]
+    shuffle(shuffled)
     st["correct"] = correct
     await m.answer(
         f"{step + 1}/{len(BLITZ_QUESTIONS)}. {question}",
-        reply_markup=kb(*(options + ["🏠 Главное меню"]), width=1),
+        reply_markup=kb(*(shuffled + ["🏠 Главное меню"]), width=1),
     )
 
 @game_router.message(lambda m: m.from_user.id in BLITZ_STATE)


### PR DESCRIPTION
## Summary
- randomize answer order for blitz questions

## Testing
- `python -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_684592fcf948832398c0bcf0fb37055a