### PR TITLE
Persist stats files on shutdown

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,9 @@
 import os
 import logging
 import json
+import atexit
+import signal
+import sys
 from datetime import datetime
 from aiogram import Bot, Dispatcher, Router, F
 from aiogram.filters import CommandStart
@@ -1823,6 +1826,19 @@ dp.include_routers(
 async def fallback_brand(m: Message):
     """Final handler to show brand info if text matches a known brand."""
     await show_brand(m)
+
+
+# --- ensure stats are persisted on shutdown ---
+def _persist_all() -> None:
+    """Save all data files immediately."""
+    save_info()
+    save_stats()
+    save_history()
+
+
+atexit.register(_persist_all)
+for _sig in (signal.SIGTERM, signal.SIGINT):
+    signal.signal(_sig, lambda s, f: (_persist_all(), sys.exit(0)))
 
 
 


### PR DESCRIPTION
## Summary
- ensure user statistics, history, and info are saved when the bot exits

## Testing
- `python3 -m py_compile bot.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_688b9991b4a48323a9614cd977c25aad