### PR TITLE
feat: store stats in redis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram==3.4.1
 flask[async]==2.3.3
 hypercorn==0.17.3
+redis==5.0.1


### PR DESCRIPTION
## Summary
- persist user stats and activity history in Redis with Asia/Almaty timezone
- split daily and cumulative tracking with non-expiring keys
- expose new admin commands for daily and total activity

## Testing
- `pip install -r requirements.txt` *(failed: Could not find a version that satisfies the requirement redis==5.0.1)*
- `python -m py_compile bot.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_689762f00f988323bcb6c3e70505a004