### PR TITLE
Add AI helper mode with local lookup and OpenAI fallback

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,6 +14,7 @@ from aiogram.types import (
     ReplyKeyboardRemove, Contact
 )
 from aiogram.utils.keyboard import ReplyKeyboardBuilder
+from routers.ai_helper import router as ai_helper_router
 
 API_TOKEN = os.getenv("TOKEN")
 if not API_TOKEN:
@@ -1873,6 +1874,7 @@ dp.include_routers(
     jager_router,
     brand_menu_router,
     suggest_router,
+    ai_helper_router
 )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiogram==3.4.1
 flask[async]==2.3.3
 hypercorn==0.17.3
 redis==5.0.1
+openai>=1.0.0

--- a/routers/ai_helper.py
+++ b/routers/ai_helper.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+from aiogram import Router, F
+from aiogram.filters import Command
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.fsm.context import FSMContext
+from aiogram.types import Message, CallbackQuery
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from dataclasses import dataclass
+from typing import Optional, Dict, List
+import os
+import re
+import time
+import csv
+from pathlib import Path
+
+router = Router()
+
+class Mode(StatesGroup):
+    ai_helper = State()
+
+def ai_menu_kb():
+    kb = InlineKeyboardBuilder()
+    kb.button(text="Выйти из AI-режима", callback_data="ai:exit")
+    return kb.as_markup()
+
+# --- анти-флуд (очень простой) ---
+_last_hit: Dict[int, float] = {}
+def rate_limited(user_id: int, interval: float = 2.0) -> bool:
+    now = time.time()
+    last = _last_hit.get(user_id, 0.0)
+    if now - last < interval:
+        return True
+    _last_hit[user_id] = now
+    return False
+
+# --- логи ---
+def log_event(user_id: int, query: str, source: str, answer_len: int) -> None:
+    Path("logs").mkdir(exist_ok=True)
+    path = Path("logs/ai_helper.csv")
+    new = not path.exists()
+    with path.open("a", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        if new:
+            w.writerow(["ts","user_id","source","q","answer_len"])
+        w.writerow([int(time.time()), user_id, source, query, answer_len])
+
+# --- нормализация ---
+def norm(s: str) -> str:
+    s = (s or "").lower().strip()
+    s = s.replace("ё", "е")
+    s = re.sub(r"[^a-zа-я0-9\s]", " ", s)
+    s = re.sub(r"\s+", " ", s)
+    return s.strip()
+# --- мини-БД (заглушка) ---
+@dataclass
+class BrandCard:
+    title: str
+    aliases: List[str]
+    summary: str
+
+_FAKE_DB: List[BrandCard] = [
+    BrandCard(
+        title="Monkey Shoulder",
+        aliases=["манки шолдер","манки","monkey shoulder","монки шолдер","мэнки шолдер","monkey"],
+        summary="Blended Malt Scotch. Мягкий вкус, хорош в чистом и в коктейлях.",
+    ),
+]
+
+_INDEX: Dict[str, BrandCard] = {}
+for c in _FAKE_DB:
+    for a in [c.title] + c.aliases:
+        _INDEX[norm(a)] = c
+
+async def find_locally(query: str) -> Optional[str]:
+    q = norm(query)
+    if q in _INDEX:
+        c = _INDEX[q]
+        return f"<b>{c.title}</b> — {c.summary}"
+    for k, c in _INDEX.items():
+        if q and (q in k or k in q):
+            return f"<b>{c.title}</b> — {c.summary}"
+    return None
+
+# --- утилита для API-ключа ---
+def _get_api_key() -> Optional[str]:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if api_key:
+        return api_key
+    env_path = Path("env/.env")
+    if env_path.exists():
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("OPENAI_API_KEY="):
+                return line.split("=",1)[1].strip()
+    return None
+
+# --- LLM вызов ---
+async def ask_llm(query: str) -> str:
+    api_key = _get_api_key()
+    if not api_key:
+        return "AI сейчас недоступен."
+    try:
+        from openai import AsyncOpenAI
+        client = AsyncOpenAI(api_key=api_key)
+        resp = await client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": query}]
+        )
+        return resp.choices[0].message.content.strip()
+    except Exception:
+        return "AI сейчас недоступен."
+
+@router.message(Command("ai"))
+async def ai_start(m: Message, state: FSMContext):
+    await state.set_state(Mode.ai_helper)
+    await m.answer(
+        "AI-помощник активирован. Напиши бренд/вопрос (например: «манки шолдер»).\n"
+        "Команда /exit — выход.",
+        reply_markup=ai_menu_kb()
+    )
+
+@router.message(Mode.ai_helper, F.text.as_("q"))
+async def ai_answer(m: Message, state: FSMContext, q: str):
+    if rate_limited(m.from_user.id):
+        return
+    local = await find_locally(q)
+    if local:
+        log_event(m.from_user.id, q, "local", len(local))
+        await m.answer(local, reply_markup=ai_menu_kb())
+        return
+    llm = await ask_llm(q)
+    log_event(m.from_user.id, q, "llm", len(llm))
+    await m.answer(llm, reply_markup=ai_menu_kb())
+
+@router.message(Mode.ai_helper, Command("exit"))
+async def ai_exit_cmd(m: Message, state: FSMContext):
+    await state.clear()
+    await m.answer("Окей, вышли из AI-режима.")
+
+@router.callback_query(F.data == "ai:exit")
+async def ai_exit_btn(c: CallbackQuery, state: FSMContext):
+    await state.clear()
+    await c.message.edit_text("Окей, вышли из AI-режима.")
+    await c.answer()

--- a/tests/test_ai_helper.py
+++ b/tests/test_ai_helper.py
@@ -1,0 +1,20 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from routers.ai_helper import norm, find_locally
+import asyncio
+
+
+def test_norm():
+    assert norm("Манки Шолдер!!!") == "манки шолдер"
+    assert norm("  monkey   shoulder ") == "monkey shoulder"
+
+
+def test_find_locally_hit():
+    ans = asyncio.run(find_locally("манки"))
+    assert ans is not None
+    assert "Monkey Shoulder" in ans
+
+
+def test_find_locally_miss():
+    ans = asyncio.run(find_locally("несуществующий бренд"))
+    assert ans is None


### PR DESCRIPTION
## Summary
- add `/ai` helper router with local DB search and OpenAI fallback
- log queries and rate limit interactions
- cover normalization and local search with unit tests

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement openai>=1.0.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b3a9cf3388323b0a6461043b52bf9