### PR TITLE
Load environment variables from .env for Bing search

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,11 @@ from aiogram.types import (
     ReplyKeyboardRemove, Contact
 )
 from aiogram.utils.keyboard import ReplyKeyboardBuilder, InlineKeyboardBuilder
+from dotenv import load_dotenv
 from routers.ai_live import router as ai_live_router
+
+# Load environment variables from .env if present
+load_dotenv()
 
 API_TOKEN = os.getenv("TOKEN")
 if not API_TOKEN:


### PR DESCRIPTION
## Summary
- load environment variables from a .env file so the Bing API key is picked up and online search works

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4a31e2fc832399558f2dd015b5d1